### PR TITLE
custom errorMessage isn't required

### DIFF
--- a/libs/sdk/express/index.ts
+++ b/libs/sdk/express/index.ts
@@ -4,7 +4,7 @@ import { FieldStateResult } from '@prici/shared-remult';
 export interface MiddlewareOptions {
   sdk: PriciSdk;
   fieldId?: string;
-  errorMessage: string;
+  errorMessage?: string;
   incrementAmount?: number;
   getAccountId?: (req?: any) => string | Promise<string>;
   getFieldId?: (req?: any) => string | Promise<string>;
@@ -17,7 +17,7 @@ export function getExpressMiddleware(opts: MiddlewareOptions) {
   const options = {
     getAccountId: async (req: any) => req.accountId || req.account?.id || req.user?.account || req.user?.tenant,
     getFieldId: async (req: any) => opts.fieldId || req.fieldId,
-    getError: async (req?: any) => opts.errorMessage || 'reached limit',
+    getError: async (req?: any) => opts.errorMessage || 'payment required',
     getIncrementAmount: () => opts.incrementAmount,
     ...opts
   }

--- a/libs/sdk/nest/index.ts
+++ b/libs/sdk/nest/index.ts
@@ -5,7 +5,7 @@ import PriciSdk from '../index';
 export interface GuardOptions {
     sdk: PriciSdk;
     fieldId?: string;
-    errorMessage: string;
+    errorMessage?: string;
     incrementAmount?: number;
     getAccountId?: (req?: any) => string | Promise<string>;
     getFieldId?: (req?: any) => string | Promise<string>;
@@ -20,7 +20,7 @@ export class IsAllowedGuard implements CanActivate {
         const opts = {
             getAccountId: async (req: any) => req.accountId || req.account?.id || req.user?.account || req.user?.tenant,
             getFieldId: async (req: any) => this.options.fieldId || req.fieldId,
-            getError: async (req?: any) => this.options.errorMessage || 'reached limit',
+            getError: async (req?: any) => this.options.errorMessage || 'payment required',
             getIncrementAmount: () => this.options.incrementAmount,
             ...this.options
         }


### PR DESCRIPTION
Issue #31 
Made errorMessage field optional both in middleware and nest guard